### PR TITLE
ci(safety): rust 1.91, miri validation, stricter lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.90"
+          toolchain: "1.91"
           components: clippy, rustfmt
 
       - name: Cache cargo
@@ -63,7 +63,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.90"
+          toolchain: "1.91"
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -83,8 +83,8 @@ jobs:
         run: |
           SIZE=$(stat -f%z target/release/timeout)
           echo "Binary size: $SIZE bytes ($(($SIZE / 1024))KB)"
-          if [ $SIZE -gt 150000 ]; then
-            echo "ERROR: Binary too large (>150KB)"
+          if [ $SIZE -gt 100000 ]; then
+            echo "ERROR: Binary too large (>100KB)"
             exit 1
           fi
 
@@ -96,3 +96,34 @@ jobs:
             echo "ERROR: Too many symbols (>100), check strip settings"
             exit 1
           fi
+
+  # Run Miri on unit tests to detect undefined behavior in unsafe code.
+  # Focuses on pure-Rust modules: sync.rs (AtomicOnce), signal.rs, duration.rs,
+  # args.rs parsing, and runner.rs exit code logic.
+  #
+  # Tests using libc FFI (process spawning, I/O, signal delivery) are gated
+  # with #[cfg(not(miri))] since Miri cannot interpret macOS syscalls like
+  # posix_spawn*, kill, or write. These are covered by integration tests.
+  miri:
+    name: Miri (UB detection)
+    needs: lint
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust nightly with Miri
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: miri
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run Miri on unit tests
+        run: cargo +nightly miri test --lib
+        env:
+          # Disable isolation to allow some FFI stubs, though most libc calls
+          # will still be unsupported. This catches UB in pure Rust unsafe code.
+          MIRIFLAGS: -Zmiri-disable-isolation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.90"
+          toolchain: "1.91"
           targets: aarch64-apple-darwin,x86_64-apple-darwin
           components: clippy, rustfmt
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "darwin-timeout"
 version = "1.1.0"
 edition = "2024"
-rust-version = "1.90"
+rust-version = "1.91"
 authors = ["denispol"]
 description = "Run a command with a time limit (GNU timeout clone for Darwin/Apple platforms)"
 license = "MIT"
@@ -47,3 +47,19 @@ path = "src/main.rs"
 
 [features]
 default = []
+
+[lints.rust]
+unsafe_op_in_unsafe_fn = "deny"
+# New in 1.91: catches raw pointers derived from locals that outlive their source.
+# Critical for FFI code where stack pointers could escape to C functions.
+dangling_pointers_from_locals = "deny"
+# Uplifted in 1.88: prevents null pointer UB in FFI calls expecting non-null args.
+invalid_null_arguments = "deny"
+
+[lints.clippy]
+# Require SAFETY comments on unsafe blocks - enforces documentation of invariants.
+undocumented_unsafe_blocks = "deny"
+# Prefer single unsafe ops per block for auditability. Allow-listed in existing
+# code where multiple operations share the same invariants (e.g., fcntl sequences,
+# sigaction setup). New code should split blocks where possible.
+multiple_unsafe_ops_per_block = "warn"

--- a/src/io.rs
+++ b/src/io.rs
@@ -121,7 +121,14 @@ macro_rules! format {
     }};
 }
 
+/*
+ * Tests for I/O primitives.
+ *
+ * Skipped under Miri: libc::write is an unsupported foreign function.
+ * These are smoke tests verifying the syscall wrappers don't crash.
+ */
 #[cfg(test)]
+#[cfg(not(miri))]
 mod tests {
     use super::*;
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -111,6 +111,8 @@ impl<T> AtomicOnce<T> {
             // SAFETY: Same as get() - Acquire load synchronizes with Release store,
             // value is immutable and was written before the Release.
             // unwrap_unchecked is safe because INITIALIZED implies Some.
+            // Deref and unwrap_unchecked share the same invariant (value is valid Some).
+            #[allow(clippy::multiple_unsafe_ops_per_block)]
             return unsafe { (*self.value.get()).as_ref().unwrap_unchecked() };
         }
 
@@ -149,7 +151,11 @@ impl<T> AtomicOnce<T> {
         // SAFETY: At this point, state is INITIALIZED (either we set it, or we
         // spin-waited until another thread set it). Acquire ordering in the spin
         // loop synchronizes with the Release store. Value is immutable and Some.
-        unsafe { (*self.value.get()).as_ref().unwrap_unchecked() }
+        // Deref and unwrap_unchecked share the same invariant (value is valid Some).
+        #[allow(clippy::multiple_unsafe_ops_per_block)]
+        unsafe {
+            (*self.value.get()).as_ref().unwrap_unchecked()
+        }
     }
 }
 


### PR DESCRIPTION
upgrade from rust 1.90 to 1.91 for new soundness lints:
- dangling_pointers_from_locals: catches stack pointers escaping to FFI
- invalid_null_arguments: prevents null UB in FFI calls

add miri CI job to detect UB in pure-rust unsafe code (AtomicOnce, parsing). FFI-dependent tests gated with #[cfg(not(miri))] since miri cannot interpret posix_spawn*/kill/write syscalls.

tighten clippy lints to deny level:
- undocumented_unsafe_blocks: enforces SAFETY comments
- unsafe_op_in_unsafe_fn: explicit unsafe in unsafe fns

add #[allow(clippy::multiple_unsafe_ops_per_block)] where ops share same invariant. improve SAFETY comments throughout.

test: 55 native, 46 miri, 110 integration all pass