### PR TITLE
test: increase timing tolerance for slow CI runners

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -661,8 +661,9 @@ fn test_timing_precision_500ms() {
         elapsed >= Duration::from_millis(450),
         "too fast: {elapsed:?}"
     );
+    /* CI VMs (especially x86_64 emulation) can be 2x slower */
     assert!(
-        elapsed < Duration::from_millis(700),
+        elapsed < Duration::from_millis(1500),
         "too slow: {elapsed:?}"
     );
 }


### PR DESCRIPTION
x86_64 CI runner took 1024ms for 500ms timeout test