### PR TITLE
ci: auto-update homebrew tap on release

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,32 @@
+name: Update Homebrew Formula
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-homebrew:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for release assets
+        run: sleep 30
+
+      - name: Get SHA256 of universal binary
+        id: sha
+        run: |
+          URL="https://github.com/denispol/darwin-timeout/releases/download/${{ github.ref_name }}/timeout-macos-universal.tar.gz"
+          SHA=$(curl -sL "$URL" | shasum -a 256 | cut -d' ' -f1)
+          echo "sha256=$SHA" >> $GITHUB_OUTPUT
+          echo "SHA256: $SHA"
+
+      - name: Update Homebrew formula
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          repository: denispol/homebrew-tap
+          event-type: update-formula
+          client-payload: |
+            {
+              "version": "${{ github.ref_name }}",
+              "sha256": "${{ steps.sha.outputs.sha256 }}"
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,44 +54,46 @@ jobs:
       - name: Create binaries
         run: |
           VERSION=${{ github.ref_name }}
-          mkdir -p dist
+          mkdir -p dist staging
           
           # ARM64 (Apple Silicon)
-          cp target/aarch64-apple-darwin/release/timeout dist/timeout
-          strip dist/timeout
-          codesign -s - dist/timeout
-          tar -C dist -czvf dist/timeout-${VERSION}-macos-arm64.tar.gz timeout
-          rm dist/timeout
+          cp target/aarch64-apple-darwin/release/timeout staging/timeout
+          strip staging/timeout
+          codesign -s - staging/timeout
+          cp -r completions staging/
+          tar -C staging -czvf dist/timeout-${VERSION}-macos-arm64.tar.gz timeout completions
+          rm staging/timeout
           
           # x86_64 (Intel)
-          cp target/x86_64-apple-darwin/release/timeout dist/timeout
-          strip dist/timeout
-          codesign -s - dist/timeout
-          tar -C dist -czvf dist/timeout-${VERSION}-macos-x86_64.tar.gz timeout
-          rm dist/timeout
+          cp target/x86_64-apple-darwin/release/timeout staging/timeout
+          strip staging/timeout
+          codesign -s - staging/timeout
+          tar -C staging -czvf dist/timeout-${VERSION}-macos-x86_64.tar.gz timeout completions
+          rm staging/timeout
           
-          # Universal
+          # Universal (also create unversioned for Homebrew)
           lipo -create \
             target/aarch64-apple-darwin/release/timeout \
             target/x86_64-apple-darwin/release/timeout \
-            -output dist/timeout
-          strip dist/timeout
-          codesign -s - dist/timeout
-          tar -C dist -czvf dist/timeout-${VERSION}-macos-universal.tar.gz timeout
-          rm dist/timeout
+            -output staging/timeout
+          strip staging/timeout
+          codesign -s - staging/timeout
+          tar -C staging -czvf dist/timeout-${VERSION}-macos-universal.tar.gz timeout completions
+          tar -C staging -czvf dist/timeout-macos-universal.tar.gz timeout completions
+          rm staging/timeout
           
           # Show results
           ls -lh dist/
 
       - name: Verify binaries
         run: |
-          for f in dist/*.tar.gz; do
+          for f in dist/timeout-${{ github.ref_name }}-*.tar.gz; do
             echo "=== $f ==="
             tar -tzf "$f"
             tar -xzf "$f" -C /tmp
             file /tmp/timeout
             /tmp/timeout --version
-            rm /tmp/timeout
+            rm -rf /tmp/timeout /tmp/completions
           done
 
       - name: Create Release


### PR DESCRIPTION
Automates Homebrew formula updates when publishing releases.

**Changes:**
- release.yml: Include shell completions in release tarball
- homebrew.yml: Trigger tap update after release publishes

**Flow on new release:**
1. Release workflow builds universal binary + completions tarball
2. Homebrew workflow computes SHA256, triggers homebrew-tap update
3. Formula auto-updates with new version and hash