### PR TITLE
docs: nanosecond precision in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Built on Darwin kernel primitives:
 - **posix_spawn**: lightweight process creation (faster than fork+exec)
 - **Signal forwarding**: SIGTERM/SIGINT/SIGHUP forwarded to child process group
 - **Process groups**: child runs in own group so signals reach all descendants
+- **kqueue + EVFILT_PROC + EVFILT_TIMER**: monitors process exit and timeout with nanosecond precision and zero CPU overhead
 
 83KB `no_std` binary. Custom allocator, direct syscalls, no libstd runtime.
 


### PR DESCRIPTION
Added a bullet point to mention nanosecond precision (like GNU utils (nanosleep), unlike uutils (100ms))