### PR TITLE
fix: enforce resource limits and monitors when timeout is zero

### DIFF
--- a/docs/resource-limits.md
+++ b/docs/resource-limits.md
@@ -214,6 +214,18 @@ Multiple limits run concurrently. The **first violation** terminates the process
 
 Note: CPU time (RLIMIT_CPU) is enforced by the kernel independently of the polling loop, so it may trigger between polls.
 
+### Without a Wall-Clock Timeout
+
+All limits above are enforced whether or not a wall-clock timeout is set. Passing a
+duration of `0` ("no timeout", run forever) still enforces `--mem-limit`,
+`--cpu-time`, `--cpu-percent`, and the `--heartbeat` / `--stdin-timeout` monitors —
+the process runs until it exits, a limit is breached, or a signal arrives.
+
+```bash
+# no wall-clock kill, but memory is still capped at 512M
+timeout --mem-limit 512M 0 ./long-running-service
+```
+
 ### JSON Output
 
 With `--json`, limits appear in the output:

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -809,8 +809,17 @@ pub fn run_command(command: &str, args: &[String], config: &RunConfig) -> Result
         SpawnError::InvalidArg => TimeoutError::Internal("invalid argument".to_string()),
     })?;
 
-    /* zero timeout = run forever */
-    if is_no_timeout(&config.timeout) {
+    /* mem-limit polling, cpu-percent throttle, heartbeat, and stdin-idle are only
+     * driven inside monitor_with_timeout. cpu_time is a spawn-time RLIMIT_CPU and
+     * needs no monitor, so it is not counted here. */
+    let needs_runtime_monitoring = config.limits.mem_bytes.is_some()
+        || config.cpu_throttle.is_some()
+        || config.heartbeat.is_some()
+        || config.stdin_timeout.is_some();
+
+    /* zero timeout = run forever: keep the zero-overhead wait only when there is
+     * nothing to monitor; otherwise fall through so limits are still enforced. */
+    if is_no_timeout(&config.timeout) && !needs_runtime_monitoring {
         let (status, rusage) = child.wait().map_err(|e| match e {
             SpawnError::Wait(errno) => TimeoutError::SpawnError(errno),
             _ => TimeoutError::Internal("wait failed".to_string()),
@@ -1001,11 +1010,19 @@ fn monitor_with_timeout(child: &mut RawChild, config: &RunConfig) -> Result<RunR
             check_interval_ns: duration_to_ns(Duration::from_millis(100)), /* poll every 100ms */
         });
 
+    /* zero duration = run forever: no wall-clock deadline, but still monitor
+     * limits/throttle/heartbeat/stdin until the child exits. */
+    let wall_timeout = if is_no_timeout(&config.timeout) {
+        None
+    } else {
+        Some(config.timeout)
+    };
+
     /* wait for exit or timeout */
     let exit_result = wait_with_kqueue(
         child,
         pid,
-        config.timeout,
+        wall_timeout,
         config.confine,
         heartbeat_config,
         stdin_timeout_config,
@@ -1075,11 +1092,13 @@ fn monitor_with_timeout(child: &mut RawChild, config: &RunConfig) -> Result<RunR
 
             /* wait for child with kill_after grace period if configured */
             if let Some(kill_after) = config.kill_after {
-                /* throttle disabled - process needs to run signal handler */
+                /* throttle disabled - process needs to run signal handler.
+                 * Some(kill_after) keeps a finite grace: --kill-after 0 escalates
+                 * immediately, unlike the None (no-deadline) main wait. */
                 let grace_result = wait_with_kqueue(
                     child,
                     pid,
-                    kill_after,
+                    Some(kill_after),
                     config.confine,
                     None,
                     None,
@@ -1189,7 +1208,7 @@ fn monitor_with_timeout(child: &mut RawChild, config: &RunConfig) -> Result<RunR
         let grace_result = wait_with_kqueue(
             child,
             pid,
-            kill_after,
+            Some(kill_after),
             config.confine,
             None,
             None,
@@ -1418,7 +1437,7 @@ fn stdin_poll_status() -> StdinPollResult {
 fn wait_with_kqueue(
     child: &mut RawChild,
     pid: i32,
-    timeout: Duration,
+    wall_timeout: Option<Duration>,
     confine: Confine,
     heartbeat: Option<HeartbeatConfig>,
     mut stdin_timeout: Option<StdinTimeoutConfig>,
@@ -1426,7 +1445,9 @@ fn wait_with_kqueue(
     memory_limit: Option<MemoryLimitConfig>,
 ) -> Result<WaitResult> {
     let start_ns = precise_now_ns(confine)?;
-    let timeout_ns = duration_to_ns(timeout);
+    /* None = no wall-clock deadline (run until exit / periodic checks only).
+     * Some(ZERO) is a finite, already-reached deadline (immediate). */
+    let timeout_ns = wall_timeout.map_or(0, duration_to_ns);
 
     /* throttle tracking */
     let throttle_interval_ns = throttle
@@ -1601,7 +1622,12 @@ fn wait_with_kqueue(
      * With heartbeat: timer fires at min(remaining_timeout, time_to_next_heartbeat).
      * With stdin timeout: timer fires at min(remaining_timeout, stdin_deadline).
      */
-    let deadline_ns = advance_ns(start_ns, timeout_ns);
+    /* no wall-clock deadline: u64::MAX is never reached, so the loop wakes only on
+     * periodic checks (mem/throttle/heartbeat/stdin) and EVFILT_PROC. */
+    let deadline_ns = match wall_timeout {
+        Some(_) => advance_ns(start_ns, timeout_ns),
+        None => u64::MAX,
+    };
 
     loop {
         /* check if we've passed deadline */

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3426,6 +3426,165 @@ fn test_cpu_time_kills_cpu_intensive() {
     );
 }
 
+/* -------------------------------------------------------------------------
+ * ZERO-DURATION ENFORCEMENT - runtime monitoring with no wall-clock timeout.
+ * Regression: the zero-duration ("run forever") fast path used to skip all
+ * post-spawn monitoring, silently disabling mem-limit/cpu-percent/heartbeat/
+ * stdin-timeout while only spawn-time RLIMIT_CPU survived.
+ * ------------------------------------------------------------------------- */
+
+#[test]
+fn test_mem_limit_kills_on_exceed_zero_duration() {
+    /*
+     * --mem-limit must still kill when there is no wall-clock timeout (0).
+     * Without the fix, the child would sleep and exit 0 unmonitored.
+     */
+    let output = timeout_cmd()
+        .args([
+            "--json",
+            "--mem-limit=5M",
+            "0", /* no wall-clock timeout */
+            "python3",
+            "-c",
+            "import time; x = [0] * (50 * 1024 * 1024 // 8); time.sleep(10)",
+        ])
+        .output()
+        .expect("command should run");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(r#""status":"memory_limit""#),
+        "mem-limit should be enforced with duration 0: {}",
+        stdout
+    );
+    assert!(
+        !output.status.success(),
+        "process should be killed by mem-limit with duration 0: {}",
+        stdout
+    );
+}
+
+#[test]
+fn test_cpu_percent_throttles_with_zero_duration() {
+    /*
+     * --cpu-percent must still engage the SIGSTOP/SIGCONT throttle with no
+     * wall-clock timeout (0). The busy loop is wall-bounded so it exits on its
+     * own; we assert the throttled path runs without hanging or being killed.
+     */
+    use std::time::Instant;
+
+    let start = Instant::now();
+    let output = timeout_cmd()
+        .args([
+            "--cpu-percent=20",
+            "0", /* no wall-clock timeout */
+            "sh",
+            "-c",
+            "i=0; end=$(($(date +%s) + 1)); while [ $(date +%s) -lt $end ]; do i=$((i+1)); done",
+        ])
+        .output()
+        .expect("command should run");
+    let elapsed = start.elapsed();
+
+    /* the throttle path must run to completion (not be skipped, not hang, not
+     * spuriously kill the child) with no wall-clock timeout. */
+    assert!(
+        output.status.success(),
+        "throttled command should complete with duration 0: {:?}",
+        output.status
+    );
+    assert!(
+        elapsed < Duration::from_secs(15),
+        "throttled command should not hang with duration 0 (took {:?})",
+        elapsed
+    );
+}
+
+#[test]
+fn test_heartbeat_with_zero_duration() {
+    /*
+     * --heartbeat must still emit ticks with no wall-clock timeout (0).
+     * sleep exits on its own; heartbeat fires during the run.
+     */
+    let output = timeout_cmd()
+        .args(["--heartbeat", "200ms", "0", "sleep", "1"])
+        .output()
+        .expect("failed to run command");
+
+    assert!(
+        output.status.success(),
+        "sleep should complete with duration 0: {:?}",
+        output.status
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("timeout: heartbeat:"),
+        "heartbeat should fire with duration 0: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_stdin_timeout_with_zero_duration() {
+    /*
+     * --stdin-timeout must still fire with no wall-clock timeout (0).
+     * Keep an open, idle pipe so the idle timer (not EOF) triggers -> exit 124.
+     */
+    use std::process::Stdio;
+    let mut child = std::process::Command::new(timeout_bin_path().as_str())
+        .args(["--stdin-timeout", "200ms", "0", "sleep", "60"])
+        .stdin(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn");
+
+    let _stdin = child.stdin.take(); /* keep pipe open and idle */
+    let status = child.wait().expect("failed to wait");
+    assert_eq!(
+        status.code(),
+        Some(124),
+        "stdin idle timeout should fire with duration 0"
+    );
+}
+
+#[test]
+fn test_kill_after_zero_escalates_immediately_zero_grace() {
+    /*
+     * --kill-after 0 must escalate to SIGKILL immediately (a finite, already-
+     * reached grace deadline), not hang. Guards the wait_with_kqueue
+     * Option<Duration> change: Some(ZERO) differs from None (no wall clock).
+     * The child ignores SIGTERM, so escalation is required to stop it.
+     */
+    use std::time::Instant;
+
+    let start = Instant::now();
+    let output = timeout_cmd()
+        .args([
+            "-s",
+            "TERM",
+            "-k",
+            "0",
+            "1s",
+            "sh",
+            "-c",
+            "trap '' TERM; sleep 30",
+        ])
+        .output()
+        .expect("command should run");
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "--kill-after 0 should escalate immediately, not hang: {:?}",
+        elapsed
+    );
+    let code = output.status.code().unwrap_or(0);
+    assert!(
+        code == 137 || code == 124 || !output.status.success(),
+        "process should be force-killed with kill-after 0 (got {})",
+        code
+    );
+}
+
 /* =========================================================================
  * DUAL BINARY BEHAVIOR - procguard vs timeout alias
  * ========================================================================= */

--- a/tests/library_api.rs
+++ b/tests/library_api.rs
@@ -197,6 +197,53 @@ fn library_run_with_retry_retries_on_timeout() {
 }
 
 /* =========================================================================
+ * RESOURCE LIMITS WITH ZERO TIMEOUT
+ * ========================================================================= */
+
+#[test]
+fn library_mem_limit_enforced_with_zero_timeout() {
+    /*
+     * limits must be enforced even when timeout is zero ("run forever").
+     * regression: run_command previously took a plain wait() fast path that
+     * skipped all monitoring when the timeout was zero.
+     */
+    use procguard::ResourceLimits;
+
+    let _ = setup_signal_forwarding();
+
+    let config = RunConfig {
+        timeout: Duration::ZERO, /* no wall-clock timeout */
+        quiet: true,
+        kill_after: Some(Duration::from_millis(50)),
+        limits: ResourceLimits {
+            mem_bytes: Some(5 * 1024 * 1024), /* 5 MiB */
+            cpu_time: None,
+        },
+        ..RunConfig::default()
+    };
+    let args = [
+        "-c".to_string(),
+        "import time; x = [0] * (50 * 1024 * 1024 // 8); time.sleep(10)".to_string(),
+    ];
+
+    let result = run_command("python3", &args, &config).expect("run_command should succeed");
+
+    match result {
+        RunResult::MemoryLimitExceeded {
+            limit_bytes,
+            actual_bytes,
+            ..
+        } => {
+            assert_eq!(limit_bytes, 5 * 1024 * 1024);
+            assert!(actual_bytes > limit_bytes);
+        }
+        _ => panic!("expected MemoryLimitExceeded with zero timeout, got other variant"),
+    }
+
+    cleanup_signal_forwarding();
+}
+
+/* =========================================================================
  * PARSING HELPERS
  * ========================================================================= */
 


### PR DESCRIPTION
- **fix(runner)**: enforce `--mem-limit`, `--cpu-percent`, `--heartbeat`, and `--stdin-timeout` when the duration is `0` ("run forever"). The zero-duration fast path returned after a plain `wait()` and never entered `monitor_with_timeout`, so all poll-based enforcement was silently skipped — only spawn-time `RLIMIT_CPU` (`--cpu-time`) survived. `run_command` now keeps the zero-overhead wait only when nothing needs monitoring.
- **fix(runner)**: `wait_with_kqueue`'s wall-clock timeout is now `Option<Duration>` — `None` = no deadline (`u64::MAX`, poll until exit); grace-period re-entries pass `Some(kill_after)` so `--kill-after 0` still escalates to SIGKILL immediately.
- **test**: duration-`0` coverage — mem-limit kill, cpu-percent throttle, heartbeat ticks, stdin-idle (exit 124), and kill-after-0 immediate (`tests/integration.rs`); mem-limit with `timeout: Duration::ZERO` (`tests/library_api.rs`).
- **docs**: note that limits (and heartbeat/stdin) are enforced with or without a wall-clock timeout.

Why? `timeout 0` means "no timeout, run forever". Since #31 that path skipped the monitor, making `--mem-limit`/`--cpu-percent` no-ops. Now enforced regardless of the wall clock, with no regression to `--kill-after 0` or the pure-wait fast path.