### PR TITLE
chore: bump version to 1.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "procguard"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "assert_cmd",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "procguard"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2024"
 rust-version = "1.91"
 authors = ["denispol"]


### PR DESCRIPTION
**chore(release)**: bump version 1.5.0 -> 1.5.1

Why? Ship the zero-timeout resource-limit fix (#36) and the rand dev-dep bump (#35).